### PR TITLE
Update Planet extension to 1.0.0-beta.3

### DIFF
--- a/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_162740_ssc1d1/20170831_162740_ssc1d1.json
+++ b/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_162740_ssc1d1/20170831_162740_ssc1d1.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20170831_162740_ssc1d1",

--- a/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json
+++ b/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20170831_172754_101c",

--- a/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_195425_SS02/20170831_195425_SS02.json
+++ b/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_195425_SS02/20170831_195425_SS02.json
@@ -4,7 +4,8 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20170831_195425_SS02",

--- a/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_195552_SS02/20170831_195552_SS02.json
+++ b/stac/disasters/hurricane-harvey/hurricane-harvey-0831/20170831_195552_SS02/20170831_195552_SS02.json
@@ -4,7 +4,8 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20170831_195552_SS02",

--- a/stac/education/bloom/20220221_145102_07_2457/20220221_145102_07_2457.json
+++ b/stac/education/bloom/20220221_145102_07_2457/20220221_145102_07_2457.json
@@ -447,7 +447,7 @@
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "collection": "Panama Bloom"
 }

--- a/stac/education/bloom/20220310_154305_84_2402/20220310_154305_84_2402.json
+++ b/stac/education/bloom/20220310_154305_84_2402/20220310_154305_84_2402.json
@@ -442,7 +442,7 @@
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "collection": "Panama Bloom"
 }

--- a/stac/open-skysat-data/20201211_103040_ssc12_u0001/20201211_103040_ssc12_u0001.json
+++ b/stac/open-skysat-data/20201211_103040_ssc12_u0001/20201211_103040_ssc12_u0001.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_103040_ssc12_u0001",

--- a/stac/open-skysat-data/20201211_223832_ssc4_u0001/20201211_223832_ssc4_u0001.json
+++ b/stac/open-skysat-data/20201211_223832_ssc4_u0001/20201211_223832_ssc4_u0001.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_ssc4_u0001",

--- a/stac/open-skysat-data/20201213_045438_ss01_u0001/20201213_045438_ss01_u0001.json
+++ b/stac/open-skysat-data/20201213_045438_ss01_u0001/20201213_045438_ss01_u0001.json
@@ -3,7 +3,8 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201213_045438_ss01_u0001",

--- a/stac/open-skysat-data/20201213_083452_ssc1_u0001/20201213_083452_ssc1_u0001.json
+++ b/stac/open-skysat-data/20201213_083452_ssc1_u0001/20201213_083452_ssc1_u0001.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201213_083452_ssc1_u0001",

--- a/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0001/20201214_032156_ssc3_u0001.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0001/20201214_032156_ssc3_u0001.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_032156_ssc3_u0001",

--- a/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0002/20201214_032156_ssc3_u0002.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0002/20201214_032156_ssc3_u0002.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_032156_ssc3_u0002",

--- a/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0001/20201214_032228_ssc3_u0001.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0001/20201214_032228_ssc3_u0001.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_032228_ssc3_u0001",

--- a/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0002/20201214_032228_ssc3_u0002.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0002/20201214_032228_ssc3_u0002.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_032228_ssc3_u0002",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0001/20201230_151832_ssc13_u0001.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0001/20201230_151832_ssc13_u0001.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201230_151832_ssc13_u0001",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0002/20201230_151832_ssc13_u0002.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0002/20201230_151832_ssc13_u0002.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201230_151832_ssc13_u0002",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0001/20201230_151906_ssc13_u0001.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0001/20201230_151906_ssc13_u0001.json
@@ -6,7 +6,7 @@
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201230_151906_ssc13_u0001",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0002/20201230_151906_ssc13_u0002.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0002/20201230_151906_ssc13_u0002.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201230_151906_ssc13_u0002",

--- a/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0001/20210101_184738_ssc13_u0001.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0001/20210101_184738_ssc13_u0001.json
@@ -6,7 +6,7 @@
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20210101_184738_ssc13_u0001",

--- a/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0002/20210101_184738_ssc13_u0002.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0002/20210101_184738_ssc13_u0002.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20210101_184738_ssc13_u0002",

--- a/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0001/20210101_184812_ssc13_u0001.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0001/20210101_184812_ssc13_u0001.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20210101_184812_ssc13_u0001",

--- a/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0002/20210101_184812_ssc13_u0002.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0002/20210101_184812_ssc13_u0002.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20210101_184812_ssc13_u0002",

--- a/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0001/20201214_180159_ssc12_u0001.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0001/20201214_180159_ssc12_u0001.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_180159_ssc12_u0001",

--- a/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0002/20201214_180159_ssc12_u0002.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0002/20201214_180159_ssc12_u0002.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_180159_ssc12_u0002",

--- a/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0001/20201214_180231_ssc12_u0001.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0001/20201214_180231_ssc12_u0001.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_180231_ssc12_u0001",

--- a/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0002/20201214_180231_ssc12_u0002.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0002/20201214_180231_ssc12_u0002.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201214_180231_ssc12_u0002",

--- a/stac/open-skysat-data/walvis-bay/20201211_090643_ssc12_u0001/20201211_090643_ssc12_u0001.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_090643_ssc12_u0001/20201211_090643_ssc12_u0001.json
@@ -3,7 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_090643_ssc12_u0001",

--- a/stac/open-skysat-data/walvis-bay/20201211_120341_ssc7_u0001/20201211_120341_ssc7_u0001.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_120341_ssc7_u0001/20201211_120341_ssc7_u0001.json
@@ -3,7 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_120341_ssc7_u0001",

--- a/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0001/20201211_155833_ssc15_u0001.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0001/20201211_155833_ssc15_u0001.json
@@ -3,7 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_155833_ssc15_u0001",

--- a/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0002/20201211_155833_ssc15_u0002.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0002/20201211_155833_ssc15_u0002.json
@@ -3,7 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.2/schema.json"
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_155833_ssc15_u0002",


### PR DESCRIPTION
- Update Planet extension to 1.0.0-beta.3
- Adds the Planet extension to the files which use SS01/02 as platform, fixes #5