### PR TITLE
Add Stereo Imagery Extension

### DIFF
--- a/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0001/20201214_032156_ssc3_u0001.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0001/20201214_032156_ssc3_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC3",
     "constellation": "skysat",
     "created": "2020-12-14T09:36:43Z",
+    "stereo-img:group": "20201214_032156_ssc3",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 1,
@@ -552,9 +556,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_032156_ssc3_u0002/20201214_032156_ssc3_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201214_032156_ssc3_u0001.json",

--- a/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0002/20201214_032156_ssc3_u0002.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032156_ssc3_u0002/20201214_032156_ssc3_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC3",
     "constellation": "skysat",
     "created": "2020-12-14T09:36:43Z",
+    "stereo-img:group": "20201214_032156_ssc3",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 1,
@@ -328,9 +332,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_032156_ssc3_u0001/20201214_032156_ssc3_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20201214_032156_ssc3_u0002.json",

--- a/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0001/20201214_032228_ssc3_u0001.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0001/20201214_032228_ssc3_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC3",
     "constellation": "skysat",
     "created": "2020-12-14T07:06:29Z",
+    "stereo-img:group": "20201214_032228_ssc3",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 1,
@@ -552,9 +556,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_032228_ssc3_u0002/20201214_032228_ssc3_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201214_032228_ssc3_u0001.json",

--- a/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0002/20201214_032228_ssc3_u0002.json
+++ b/stac/open-skysat-data/angkor-wat/20201214_032228_ssc3_u0002/20201214_032228_ssc3_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC3",
     "constellation": "skysat",
     "created": "2020-12-14T07:06:29Z",
+    "stereo-img:group": "20201214_032228_ssc3",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 1,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 1,
@@ -328,9 +332,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_032228_ssc3_u0001/20201214_032228_ssc3_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20201214_032228_ssc3_u0002.json",

--- a/stac/open-skysat-data/angkor-wat/stereo.json
+++ b/stac/open-skysat-data/angkor-wat/stereo.json
@@ -1,7 +1,8 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json"
   ],
   "type": "Catalog",
   "id": "angkor-wat-stereo",
@@ -9,6 +10,7 @@
   "description": "Stereo captures of Angkor Wat, Cambodia. This collection was tasked for the [Cloud Native Geospatial Awards](https://medium.com/radiant-earth-insights/cloud-native-geospatial-sprint-awards-bounties-4f929727aa9c), selected by Rob Emanuele. The 4 captures include [Basic L1A All Frames](https://assets.planet.com/docs/Planet_Basic_L1A_All-Frames_User_Guide.pdf) products to enable 3d reconstruction. \n\n*NOTE:* The captures right now only have Visual and L1A All Frames assets, they will eventually be updated to include analytic outputs.",
   "experimental": true,
   "license": "CC-BY-4.0",
+  "stereo-img:count": 2,
   "links": [
     {
       "href": "../../catalog.json",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0001/20201230_151832_ssc13_u0001.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0001/20201230_151832_ssc13_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2020-12-30T20:29:11Z",
+    "stereo-img:group": "20201230_151832_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 2,
     "pl:clear_percent": 97,
     "pl:ground_control_ratio": 0.92,
@@ -608,9 +612,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201230_151832_ssc13_u0002/20201230_151832_ssc13_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201230_151832_ssc13_u0001.json",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0002/20201230_151832_ssc13_u0002.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151832_ssc13_u0002/20201230_151832_ssc13_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2020-12-30T20:29:12Z",
+    "stereo-img:group": "20201230_151832_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 2,
     "pl:clear_percent": 97,
     "pl:ground_control_ratio": 0.94,
@@ -368,9 +372,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201230_151832_ssc13_u0001/20201230_151832_ssc13_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20201230_151832_ssc13_u0002.json",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0001/20201230_151906_ssc13_u0001.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0001/20201230_151906_ssc13_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
@@ -17,6 +18,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2020-12-30T19:17:47Z",
+    "stereo-img:group": "20201230_151906_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 3,
     "pl:clear_percent": 97,
     "pl:ground_control_ratio": 1,
@@ -734,9 +738,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201230_151906_ssc13_u0002/20201230_151906_ssc13_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201230_151906_ssc13_u0001.json",

--- a/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0002/20201230_151906_ssc13_u0002.json
+++ b/stac/open-skysat-data/cocabamba-peru/20201230_151906_ssc13_u0002/20201230_151906_ssc13_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -15,6 +16,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2020-12-30T19:17:47Z",
+    "stereo-img:group": "20201230_151906_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 97,
     "pl:ground_control_ratio": 1,
@@ -338,9 +342,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201230_151906_ssc13_u0001/20201230_151906_ssc13_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20201230_151906_ssc13_u0002.json",

--- a/stac/open-skysat-data/cocabamba-peru/stereo.json
+++ b/stac/open-skysat-data/cocabamba-peru/stereo.json
@@ -1,7 +1,8 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json"
   ],
   "type": "Catalog",
   "id": "cocabamba-peru-stereo",
@@ -9,6 +10,7 @@
   "description": "Stereo captures of Cocabamba, Perú . This collection was tasked for the [Cloud Native Geospatial Awards](https://medium.com/radiant-earth-insights/cloud-native-geospatial-sprint-awards-bounties-4f929727aa9c), selected by Jhomira Loja Zumaeta. The 4 captures include [Basic L1A All Frames](https://assets.planet.com/docs/Planet_Basic_L1A_All-Frames_User_Guide.pdf) products to enable 3d reconstruction. \n\n*NOTE:* The captures right now only have Visual and L1A All Frames assets, they will eventually be updated to include analytic outputs.",
   "experimental": true,
   "license": "CC-BY-4.0",
+  "stereo-img:count": 2,
   "links": [
     {
       "href": "../../catalog.json",

--- a/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0001/20210101_184738_ssc13_u0001.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0001/20210101_184738_ssc13_u0001.json
@@ -5,6 +5,7 @@
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -17,6 +18,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2021-01-01T23:59:43Z",
+    "stereo-img:group": "20210101_184738_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 0,
     "eo:snow_cover": 0,
     "pl:clear_percent": 98,
@@ -771,9 +775,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20210101_184738_ssc13_u0002/20210101_184738_ssc13_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20210101_184738_ssc13_u0001.json",

--- a/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0002/20210101_184738_ssc13_u0002.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184738_ssc13_u0002/20210101_184738_ssc13_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2021-01-01T23:59:43Z",
+    "stereo-img:group": "20210101_184738_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 0,
     "eo:snow_cover": 0,
     "pl:clear_percent": 98,
@@ -412,9 +416,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20210101_184738_ssc13_u0001/20210101_184738_ssc13_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20210101_184738_ssc13_u0002.json",

--- a/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0001/20210101_184812_ssc13_u0001.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0001/20210101_184812_ssc13_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2021-01-01T23:57:07Z",
+    "stereo-img:group": "20210101_184812_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 0,
     "eo:snow_cover": 0,
     "pl:clear_percent": 97,
@@ -648,9 +652,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20210101_184812_ssc13_u0002/20201214_032156_ssc3_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20210101_184812_ssc13_u0001.json",

--- a/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0002/20210101_184812_ssc13_u0002.json
+++ b/stac/open-skysat-data/san-francisco/20210101_184812_ssc13_u0002/20210101_184812_ssc13_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC13",
     "constellation": "skysat",
     "created": "2021-01-01T23:57:07Z",
+    "stereo-img:group": "20210101_184812_ssc13",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 0,
     "eo:snow_cover": 0,
     "pl:clear_percent": 97,
@@ -412,9 +416,15 @@
       "type": "application/json"
     },
     {
-      "href": "../catalog.json",
+      "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20210101_184812_ssc13_u0001/20210101_184812_ssc13_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20210101_184812_ssc13_u0002.json",

--- a/stac/open-skysat-data/san-francisco/stereo.json
+++ b/stac/open-skysat-data/san-francisco/stereo.json
@@ -1,14 +1,15 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json"
   ],
   "type": "Catalog",
   "id": "san-francisco-stereo",
   "title": "Stereo Collect",
     "description": "Stereo captures of San Francisco, California, United States. This collection was tasked for the [Cloud Native Geospatial Awards](https://medium.com/radiant-earth-insights/cloud-native-geospatial-sprint-awards-bounties-4f929727aa9c). The 4 captures include visual, analytic and [Basic L1A All Frames](https://assets.planet.com/docs/Planet_Basic_L1A_All-Frames_User_Guide.pdf) products to enable 3d reconstruction. \n\n*NOTE:* The captures right now do not have a Surface Reflectance analytic output, but will aim to update with that in the future.",
   "license": "CC-BY-4.0",
-  "experimental": true,
+  "stereo-img:count": 2,
   "links": [
     {
       "href": "../../catalog.json",

--- a/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0001/20201214_180159_ssc12_u0001.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0001/20201214_180159_ssc12_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -18,6 +19,9 @@
     "created": "2020-12-14T22:09:09Z",
     "eo:cloud_cover": 0,
     "eo:snow_cover": 4,
+    "stereo-img:group": "20201214_180159_ssc12",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "pl:clear_percent": 89,
     "pl:ground_control_ratio": 1,
     "pl:item_type": "SkySatCollect",
@@ -644,6 +648,12 @@
       "href": "../stereo.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_180159_ssc12_u0002/20201214_180159_ssc12_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201214_180159_ssc12_u0001.json",

--- a/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0002/20201214_180159_ssc12_u0002.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180159_ssc12_u0002/20201214_180159_ssc12_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC12",
     "constellation": "skysat",
     "created": "2020-12-14T22:09:09Z",
+    "stereo-img:group": "20201214_180159_ssc12",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 8,
     "eo:snow_cover": 4,
     "pl:clear_percent": 89,
@@ -466,6 +470,12 @@
       "rel": "collection",
       "title": "SP Crater, Arizona, United States",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_180159_ssc12_u0001/20201214_180159_ssc12_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "../stereo.json",

--- a/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0001/20201214_180231_ssc12_u0001.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0001/20201214_180231_ssc12_u0001.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC12",
     "constellation": "skysat",
     "created": "2020-12-14T22:21:19Z",
+    "stereo-img:group": "20201214_180231_ssc12",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 2,
     "eo:snow_cover": 8,
     "pl:clear_percent": 82,
@@ -642,6 +646,12 @@
       "rel": "collection",
       "title": "SP Crater, Arizona, United States",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_180231_ssc12_u0002/20201214_180231_ssc12_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "../stereo.json",

--- a/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0002/20201214_180231_ssc12_u0002.json
+++ b/stac/open-skysat-data/sp-crater/20201214_180231_ssc12_u0002/20201214_180231_ssc12_u0002.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
@@ -16,6 +17,9 @@
     "platform": "SSC12",
     "constellation": "skysat",
     "created": "2020-12-14T22:21:19Z",
+    "stereo-img:group": "20201214_180231_ssc12",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 7,
     "eo:snow_cover": 8,
     "pl:clear_percent": 82,
@@ -424,6 +428,12 @@
       "rel": "collection",
       "title": "SP Crater, Arizona, United States",
       "type": "application/json"
+    },
+    {
+      "href": "../20201214_180231_ssc12_u0001/20201214_180231_ssc12_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "../stereo.json",

--- a/stac/open-skysat-data/sp-crater/stereo.json
+++ b/stac/open-skysat-data/sp-crater/stereo.json
@@ -1,11 +1,14 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json"
+  ],
   "type": "Catalog",
   "id": "sp-crater-stereo",
   "title": "Stereo Collect",
   "description": "Stereo captures of SP Crater, Arizona. This collection was tasked for the [Cloud Native Geospatial Awards](https://medium.com/radiant-earth-insights/cloud-native-geospatial-sprint-awards-bounties-4f929727aa9c), selected by Robin Fergason. The 4 captures include [Basic L1A All Frames](https://assets.planet.com/docs/Planet_Basic_L1A_All-Frames_User_Guide.pdf) products to enable 3d reconstruction. \n\n*NOTE:* The captures right now only have Visual and L1A All Frames assets, they will eventually be updated to include analytic outputs.",
   "license": "CC-BY-4.0",
+  "stereo-img:count": 2,
   "links": [
     {
       "href": "../../catalog.json",

--- a/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0001/20201211_155833_ssc15_u0001.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0001/20201211_155833_ssc15_u0001.json
@@ -2,6 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -14,6 +15,9 @@
     "platform": "SSC15",
     "constellation": "skysat",
     "created": "2020-12-11T20:22:52Z",
+    "stereo-img:group": "20201211_155833_ssc15",
+    "stereo-img:count": 2,
+    "stereo-img:number": 1,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 0.37,
@@ -531,6 +535,12 @@
       "href": "../catalog.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201211_155833_ssc15_u0002/20201211_155833_ssc15_u0002.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 2
     },
     {
       "href": "./20201211_155833_ssc15_u0001.json",

--- a/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0002/20201211_155833_ssc15_u0002.json
+++ b/stac/open-skysat-data/walvis-bay/20201211_155833_ssc15_u0002/20201211_155833_ssc15_u0002.json
@@ -2,6 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://planetlabs.github.io/stac-extension/v1.0.0-beta.3/schema.json"
   ],
@@ -14,6 +15,9 @@
     "platform": "SSC15",
     "constellation": "skysat",
     "created": "2020-12-11T20:22:52Z",
+    "stereo-img:group": "20201211_155833_ssc15",
+    "stereo-img:count": 2,
+    "stereo-img:number": 2,
     "eo:cloud_cover": 0,
     "pl:clear_percent": 99,
     "pl:ground_control_ratio": 0.44,
@@ -307,6 +311,12 @@
       "href": "../catalog.json",
       "rel": "parent",
       "type": "application/json"
+    },
+    {
+      "href": "../20201211_155833_ssc15_u0001/20201211_155833_ssc15_u0001.json",
+      "rel": "related",
+      "type": "application/json",
+      "stereo-img:number": 1
     },
     {
       "href": "./20201211_155833_ssc15_u0002.json",


### PR DESCRIPTION
Adds the stereo imagery extension to the open SkySat data that has 3D components + one stereo capture in Walvis Bay.