### PR TITLE
Use a fixed path prefix and change history mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ deploy:
     url: https://static.prod.planet-labs.com/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/
     on_stop: undeploy
   script:
-    - static deploy --dir build/stac
+    - static deploy --dir build/stac --config static.json
 
 undeploy:
   stage: deploy

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ build/.browser-$(STAC_BROWSER_SHA):
 	@docker run \
 		--volume $$(pwd)/stac-browser:/stac-browser \
 		--workdir /stac-browser \
-		$(NODE) sh -c 'npm install && npm run build:minimal -- --pathPrefix="./" --historyMode=hash'
-	@mkdir -p build/stac
-	@cp -r stac-browser/dist/* build/stac
+		$(NODE) sh -c 'npm install && npm run build:minimal -- --pathPrefix="/data/stac/browser/"'
+	@mkdir -p build/stac/browser
+	@cp -r stac-browser/dist/* build/stac/browser
 	touch $@
 
 

--- a/static.json
+++ b/static.json
@@ -1,0 +1,13 @@
+{
+  "paths": [
+    {
+      "match": "^index.html$",
+      "replace": "browser/",
+      "status": 301
+    },
+    {
+      "match": ".*",
+      "replace": "browser/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This change updates the STAC Browser [history mode](https://github.com/radiantearth/stac-browser/blob/main/docs/options.md#historymode) from `hashed` to `history`.  As a consequence, the build will only work when deployed to the `/data/stac/browser/` path.