### PR TITLE
Updated license for Brandenburg collection

### DIFF
--- a/stac/education/brandenburg/2024-08-13_analysis_ready_ps_sr.json
+++ b/stac/education/brandenburg/2024-08-13_analysis_ready_ps_sr.json
@@ -17,7 +17,7 @@
       "landsat",
       "sentinel-2"
     ],
-    "license": "CC-BY-SA-4.0",
+    "license": "CC-BY-4.0",
     "proj:bbox": [
       383997,
       5784000,

--- a/stac/education/brandenburg/collection.json
+++ b/stac/education/brandenburg/collection.json
@@ -43,5 +43,5 @@
       "type": "application/json"
     }
   ],
-  "license": "CC-BY-SA-4.0"
+  "license": "CC-BY-4.0"
 }


### PR DESCRIPTION
This updates the license for the Brandenburg collection to [CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)