### PR TITLE
Avoid using "Release 2" title for Tanager open data release

### DIFF
--- a/stac/tanager-core-imagery/GHG-plumes/collection.json
+++ b/stac/tanager-core-imagery/GHG-plumes/collection.json
@@ -124,7 +124,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/ROCX2025/collection.json
+++ b/stac/tanager-core-imagery/ROCX2025/collection.json
@@ -234,7 +234,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/agriculture/collection.json
+++ b/stac/tanager-core-imagery/agriculture/collection.json
@@ -531,7 +531,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/catalog.json
+++ b/stac/tanager-core-imagery/catalog.json
@@ -2,7 +2,7 @@
   "stac_version": "1.1.0",
   "type": "Catalog",
   "id": "tanager-core-imagery-v2",
-  "title": "Tanager Core Imagery Release 2",
+  "title": "Tanager Core Imagery",
   "description": "Tanager Core Imagery Sample Products - Basic (georeferenced, unprojected) and orthorectified (georeferenced, projected) core imagery data products from Tanager-1 hyperspectral satellite.\n             The data included in this Tanager STAC Catalogue (the \"Licensed Material\") is made available under the Creative Commons CC-BY 4.0 license (https://creativecommons.org/licenses/by/4.0/).\n             Use the following attribution for any redistribution of the Licensed Materials, \"Tanager STAC Data, available at www.planet.com/data/stac © [YEAR] Planet Labs PBC. All Rights Reserved\",\n             and preface with \"Adapted from...\" for any Adapted Material. Where [YEAR] means the year in which the data was captured by the Tanager satellite, as indicated for each data collection. ",
   "links": [
     {

--- a/stac/tanager-core-imagery/coastal-water-bodies/collection.json
+++ b/stac/tanager-core-imagery/coastal-water-bodies/collection.json
@@ -531,7 +531,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/energy-mining/collection.json
+++ b/stac/tanager-core-imagery/energy-mining/collection.json
@@ -245,7 +245,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/fire/collection.json
+++ b/stac/tanager-core-imagery/fire/collection.json
@@ -179,7 +179,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/natural-lands/collection.json
+++ b/stac/tanager-core-imagery/natural-lands/collection.json
@@ -839,7 +839,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/snow-ice/collection.json
+++ b/stac/tanager-core-imagery/snow-ice/collection.json
@@ -135,7 +135,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],

--- a/stac/tanager-core-imagery/urban/collection.json
+++ b/stac/tanager-core-imagery/urban/collection.json
@@ -674,7 +674,7 @@
     {
       "href": "../catalog.json",
       "rel": "parent",
-      "title": "Tanager Core Imagery Release 2",
+      "title": "Tanager Core Imagery",
       "type": "application/json"
     }
   ],


### PR DESCRIPTION
We've been asked to avoid calling the new release of Tanager open data "Release 2" to avoid confusion.  This MR leaves "Release 2" out of the STAC catalog title.  

Note that `release2` is still in the file paths, but we're not being asked to change things at that level.  E.g. the first release files are still in GCS and data for the same scenes in the second release is actually different.  We need to keep both sets of data files for end users consistency outside of these STAC catalogs (e.g. the "release 1" data is used directly in GEE without STAC being used at all in https://gee-community-catalog.org/projects/tanager/ and we don't want to break that).